### PR TITLE
Use `git branch --set-upstream` instead of `git config`

### DIFF
--- a/lib/git_remote_branch.rb
+++ b/lib/git_remote_branch.rb
@@ -46,8 +46,7 @@ module GitRemoteBranch
       :commands => [
         '"#{GIT} push #{origin} #{branch_name}:refs/heads/#{branch_name}"',
         '"#{GIT} fetch #{origin}"',
-        '"#{GIT} config branch.#{branch_name}.remote #{origin}"',
-        '"#{GIT} config branch.#{branch_name}.merge refs/heads/#{branch_name}"',
+        '"#{GIT} branch --set-upstream #{branch_name} #{origin}/#{branch_name}"',
         '"#{GIT} checkout #{branch_name}"'
       ]
     },
@@ -79,14 +78,8 @@ module GitRemoteBranch
       :description => 'track an existing remote branch',
       :aliases  => %w{track follow grab fetch},
       :commands => [
-        # This string programming thing is getting old. Not flexible enough anymore.
         '"#{GIT} fetch #{origin}"',
-        'if local_branches.include?(branch_name) 
-          "#{GIT} config branch.#{branch_name}.remote #{origin}\n" +
-          "#{GIT} config branch.#{branch_name}.merge refs/heads/#{branch_name}"
-        else
-          "#{GIT} branch --track #{branch_name} #{origin}/#{branch_name}"
-        end'
+        '"#{GIT} branch --set-upstream #{branch_name} #{origin}/#{branch_name}"'
       ]
     }
   } unless defined?(COMMANDS)

--- a/test/functional/grb_test.rb
+++ b/test/functional/grb_test.rb
@@ -32,8 +32,8 @@ class GRBTest < Test::Unit::TestCase
           
           should_have_branch 'new_branch', :local, :remote
           
-          should "use the branch --track command" do
-            assert_match %r{branch --track}, @output
+          should "use the branch --set-upstream command" do
+            assert_match %r{branch --set-upstream}, @output
           end
         end
         
@@ -45,8 +45,8 @@ class GRBTest < Test::Unit::TestCase
           
           should_have_branch 'new_branch', :local, :remote
           
-          should "use git config to connect the branches" do
-            assert_match %r{git\sconfig}, @output
+          should "use the branch --set-upstream command" do
+            assert_match %r{branch --set-upstream}, @output
           end
         end
       end


### PR DESCRIPTION
I recently noticed that grb publish and grb track don't respect the branch.autosetuprebase git config option.  Implementing this support would be somewhat complicated, and it still doesn't solve the generally problem of creating remote-tracking branches with support for all current and future git config options.  As of git 1.7.0, git branch (and git push) have a --set-upstream option.  This sets all the appropriate config options for a remote-tracking branch (and will create a local branch if it does not exist yet).
