### PR TITLE
Ruby1.9.2 support

### DIFF
--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -3,8 +3,8 @@ require 'yaml'
 require 'rake/gempackagetask'
 
 spec = Gem::Specification.new do |s|
-  s.name                  = GitRemoteBranch::NAME
-  s.version               = GitRemoteBranch::VERSION::STRING
+  s.name                  = GitRemoteBranch::NAME.dup
+  s.version               = GitRemoteBranch::VERSION::STRING.dup
   s.summary               = "git_remote_branch eases the interaction with remote branches"
   s.description           = "git_remote_branch is a learning tool to ease the interaction with " +
                             "remote branches in simple situations."

--- a/test/functional/grb_test.rb
+++ b/test/functional/grb_test.rb
@@ -1,4 +1,4 @@
-require File.join( File.dirname(__FILE__), '..', 'test_helper')
+require File.expand_path('../../test_helper', __FILE__)
 
 class GRBTest < Test::Unit::TestCase
   include ShouldaFunctionalHelpers

--- a/test/unit/git_helper_test.rb
+++ b/test/unit/git_helper_test.rb
@@ -1,4 +1,4 @@
-require File.join( File.dirname(__FILE__), '..', 'test_helper')
+require File.expand_path('../../test_helper', __FILE__)
 
 class GitHelperTest < Test::Unit::TestCase
   

--- a/test/unit/git_remote_branch_test.rb
+++ b/test/unit/git_remote_branch_test.rb
@@ -1,4 +1,4 @@
-require File.join( File.dirname(__FILE__), '..', 'test_helper')
+require File.expand_path('../../test_helper', __FILE__)
 
 class GitRemoteBranchTest < Test::Unit::TestCase
   context 'help' do

--- a/test/unit/param_reader_test.rb
+++ b/test/unit/param_reader_test.rb
@@ -1,4 +1,4 @@
-require File.join( File.dirname(__FILE__), '..', 'test_helper')
+require File.expand_path('../../test_helper', __FILE__)
 require "#{TEST_DIR}/helpers/constants"
 
 class ParamReaderTest < Test::Unit::TestCase
@@ -194,7 +194,7 @@ class ParamReaderTest < Test::Unit::TestCase
     GitRemoteBranch::COMMANDS.each_pair do |cmd, params|
       should "recognize all #{cmd} aliases" do
         params[:aliases].each do |alias_|
-          assert cmd, grb.get_action(alias_) 
+          assert cmd, grb.get_action(alias_).to_s
         end
       end
     end

--- a/test/unit/state_test.rb
+++ b/test/unit/state_test.rb
@@ -1,4 +1,4 @@
-require File.join( File.dirname(__FILE__), '..', 'test_helper')
+require File.expand_path('../../test_helper', __FILE__)
 require "#{TEST_DIR}/helpers/constants"
 
 class ParamReaderTest < Test::Unit::TestCase


### PR DESCRIPTION
A couple of patches to get tests passing under ruby 1.9.2.  I'm using RVM on Mac OSX 10.6.6.

$ ruby -v
ruby 1.8.7 (2010-04-19 patchlevel 253) [i686-darwin10.4.1], MBARI 0x6770, Ruby Enterprise Edition 2010.02
