### PR TITLE
--include-dependencies is now default and will be removed in a future ve...

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,7 +17,7 @@ same name. Multiple remote repositories (or origins) are supported.
 
 = Installation
 
-  sudo gem install git_remote_branch --include-dependencies
+  sudo gem install git_remote_branch
 
 If you have an old version of Rubygems, you may have to manually install the "colored" gem.
   sudo gem install colored


### PR DESCRIPTION
--include-dependencies is now default and will be removed in a future version of RubyGems
