### PR TITLE
git remote-branch

### DIFF
--- a/bin/git-remote-branch
+++ b/bin/git-remote-branch
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+load File.join(File.dirname(__FILE__), 'grb')


### PR DESCRIPTION
I've created git-remote-branch bin which just loads grb, this allows using grb in same manner as other git tools: `git remote-branch`
