### PR TITLE
Add grb-completion.bash for lazy people

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -35,7 +35,8 @@ you can have grb auto-completion by using the {git-remote-branch plugin}[https:/
 If you use bash, you can have grb auto-completion by souring `etc/grb-completion.bash`
 
   # ~/.bash_profile
-  source `gem contents git_remote_branch | grep grb-completion.bash`
+
+  [[ -s grb ]] && source `gem contents git_remote_branch | grep grb-completion.bash`
 
 or copy it to your desired destination and source it.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -32,6 +32,13 @@ you can have grb auto-completion by using the {git-remote-branch plugin}[https:/
   # ~/.zshrc
   plugins=(git git-remote-branch ...)
 
+If you use bash, you can have grb auto-completion by souring `etc/grb-completion.bash`
+
+  # ~/.bash_profile
+  source `gem contents git_remote_branch | grep grb-completion.bash`
+
+or copy it to your desired destination and source it.
+
 == Usage
 
 Notes:

--- a/etc/grb-completion.bash
+++ b/etc/grb-completion.bash
@@ -1,0 +1,47 @@
+_grb()
+{
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    local verb=${COMP_WORDS[1]}
+
+    local position=${COMP_CWORD}
+    
+    if [[ "$verb" == "explain" ]]; then
+        let "position = $position - 1"
+    fi
+
+    case "$position" in
+        1)
+            COMPREPLY=( $(compgen -W "help explain create new delete destroy kill remove rm rename rn mv move track follow grab fetch" -- $cur) )
+            ;;
+        2)
+
+            COMPREPLY=( $(compgen -W "$(_grb_branch)" -- $cur))
+            ;;
+        3)
+
+            COMPREPLY=( $(compgen -W "$(_grb_remotes)" -- $cur))
+            ;;
+    esac
+}
+
+_grb_branch()
+{
+   {
+       git for-each-ref refs/remotes --format="%(refname:short)" | 
+       grep -v HEAD |
+       sed 's/^.*\///g'; 
+       git for-each-ref refs/heads --format="%(refname:short)";
+   } | sort | uniq
+}
+
+_grb_remotes()
+{
+	local i IFS=$'\n'
+	for i in $(git config --get-regexp 'remote\..*\.url' 2>/dev/null); do
+		i="${i#remote.}"
+		echo "${i/.url*/}"
+	done
+}
+
+complete -F _grb grb
+


### PR DESCRIPTION
Usage: `source grb-completion.bash`

No more typing long branch names anymore.
