### PR TITLE
Use rainbow's presenter object instead of mixin for output coloration

### DIFF
--- a/git_remote_branch.gemspec
+++ b/git_remote_branch.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
-  s.add_dependency 'rainbow'
+  s.add_dependency 'rainbow', '~> 2.0.0'
 end

--- a/lib/git_remote_branch.rb
+++ b/lib/git_remote_branch.rb
@@ -142,7 +142,7 @@ module GitRemoteBranch
 
   def puts_cmd(*cmds)
     cmds.flatten.each do |c|
-      whisper "#{c}".foreground(:red)
+      whisper Rainbow("#{c}").foreground(:red)
     end
   end
 end

--- a/lib/state.rb
+++ b/lib/state.rb
@@ -27,7 +27,7 @@ module GitRemoteBranch
       raise(NotOnGitRepositoryError, listing.chomp) if listing =~ /Not a git repository/i
       if listing =~ /\(no branch\)/
         raise InvalidBranchError, ["Couldn't identify the current local branch. The branch listing was:",
-          LOCAL_BRANCH_LISTING_COMMAND.foreground(:red),
+          Rainbow(LOCAL_BRANCH_LISTING_COMMAND).foreground(:red),
           listing].join("\n")
       end
 


### PR DESCRIPTION
In Rainbow 2.0, the string mixin was removed by default. This is mostly
a great thing, because it doesn't pollute the global namespace.

However, it breaks git_remote_branch.

Rainbow has been pinned to 2.0.x with the twiddle wakka because older
versions are not friendly to the new syntax.

fixes #16
